### PR TITLE
fix: return complete cert chain in tls.crt

### DIFF
--- a/pkg/issuer/pca.go
+++ b/pkg/issuer/pca.go
@@ -56,7 +56,8 @@ func (i *IssuerManager) Sign(ctx context.Context, cr signer.CertificateRequestOb
 		return signer.PEMBundle{}, err
 	}
 	if resp != nil && resp.Body != nil {
-		pemBundle, err := pki.ParseSingleCertificateChainPEM([]byte(tea.StringValue(resp.Body.Certificate)))
+		fullChain := tea.StringValue(resp.Body.Certificate) + "\n" + tea.StringValue(resp.Body.CertificateChain)
+		pemBundle, err := pki.ParseSingleCertificateChainPEM([]byte(fullChain))
 		if err != nil {
 			return signer.PEMBundle{}, fmt.Errorf("parse %s single certificate chain pem error %v", key, err)
 		}


### PR DESCRIPTION
Similar to this fix in AWS PCA cert-manager: https://github.com/cert-manager/aws-privateca-issuer/blob/88525d4e6cd24651003dce464100b4d657197115/pkg/aws/pca.go#L162

The returned certificate should contain the full chain, so browsers and other clients can verify the full trust chain.